### PR TITLE
remove z-index

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -24,7 +24,6 @@ body {
 
 .page-content {
   position: relative;
-  z-index: 100;
 }
 
 h1, h2 {


### PR DESCRIPTION
Removing the z-index on `page-content` element fixes issue #30. Tested this across other pages and the mobile nav still seems to work. 

@dakotabenjamin can you test? 